### PR TITLE
Make an FM geolib version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken = ${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flitsmeister/geolib",
-  "version": "3.3.4",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "geolib",
+  "name": "@flitsmeister/geolib",
   "version": "3.3.4",
   "description": "",
   "main": "lib/index.js",
@@ -23,14 +23,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/manuelbieh/geolib.git"
+    "url": "git+https://github.com/flitsmeister/geolib.git"
   },
   "author": "Manuel Bieh",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/manuelbieh/geolib/issues"
+    "url": "https://github.com/flitsmeister/geolib/issues"
   },
-  "homepage": "https://github.com/manuelbieh/geolib#readme",
+  "homepage": "https://github.com/flitsmeister/geolib",
   "scripts": {
     "babel": "babel",
     "build": "yarn clean && yarn build:es && yarn build:types && yarn build:umd",
@@ -71,7 +71,6 @@
     "eslint-plugin-react-hooks": "^4.0.2",
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-unicorn": "^20.0.0",
-    "husky": "^4.2.5",
     "install-deps-postmerge": "^1.0.5",
     "jest": "^26.0.1",
     "lint-staged": "^10.2.6",

--- a/src/getLatitude.ts
+++ b/src/getLatitude.ts
@@ -4,15 +4,7 @@ import getCoordinateKey from './getCoordinateKey';
 import toDecimal from './toDecimal';
 
 const getLatitude = (point: GeolibInputCoordinates, raw?: boolean) => {
-    const latKey = getCoordinateKey(point, latitudeKeys);
-
-    if (typeof latKey === 'undefined' || latKey === null) {
-        return;
-    }
-
-    const value = point[latKey as keyof LatitudeKeys];
-
-    return raw === true ? value : toDecimal(value);
+    return point.latitude;
 };
 
 export default getLatitude;

--- a/src/getLongitude.ts
+++ b/src/getLongitude.ts
@@ -4,15 +4,7 @@ import getCoordinateKey from './getCoordinateKey';
 import toDecimal from './toDecimal';
 
 const getLongitude = (point: GeolibInputCoordinates, raw?: boolean) => {
-    const latKey = getCoordinateKey(point, longitudeKeys);
-
-    if (typeof latKey === 'undefined' || latKey === null) {
-        return;
-    }
-
-    const value = point[latKey as keyof LongitudeKeys];
-
-    return raw === true ? value : toDecimal(value);
+    return point.longitude;
 };
 
 export default getLongitude;

--- a/src/getPreciseDistance.ts
+++ b/src/getPreciseDistance.ts
@@ -31,12 +31,8 @@ const getDistance = (
     let cos2SigmaM;
     let sinSigma;
 
-    const U1 = Math.atan(
-        (1 - ellipsoidParams) * Math.tan(toRad(parseFloat(startLat)))
-    );
-    const U2 = Math.atan(
-        (1 - ellipsoidParams) * Math.tan(toRad(parseFloat(endLat)))
-    );
+    const U1 = Math.atan((1 - ellipsoidParams) * Math.tan(toRad(startLat)));
+    const U2 = Math.atan((1 - ellipsoidParams) * Math.tan(toRad(endLat)));
     const sinU1 = Math.sin(U1);
     const cosU1 = Math.cos(U1);
     const sinU2 = Math.sin(U2);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,14 +12,9 @@ export type LongitudeKeys = 'lng' | 'lon' | 'longitude' | 0;
 export type LatitudeKeys = 'lat' | 'latitude' | 1;
 export type AltitudeKeys = 'alt' | 'altitude' | 'elevation' | 'elev' | 2;
 
-export type GeolibInputLongitude =
-    | { lng: GeolibLongitudeInputValue }
-    | { lon: GeolibLongitudeInputValue }
-    | { longitude: GeolibLongitudeInputValue };
+export type GeolibInputLongitude = { longitude: GeolibLongitudeInputValue };
 
-export type GeolibInputLatitude =
-    | { lat: GeolibLatitudeInputValue }
-    | { latitude: GeolibLatitudeInputValue };
+export type GeolibInputLatitude = { latitude: GeolibLatitudeInputValue };
 
 export type GeolibInputAltitude =
     | { alt?: GeolibAltitudeInputValue }
@@ -31,7 +26,7 @@ export type UserInputCoordinates = GeolibInputLongitude &
     GeolibInputLatitude &
     GeolibInputAltitude;
 
-export type GeolibInputCoordinates = UserInputCoordinates | GeolibGeoJSONPoint;
+export type GeolibInputCoordinates = { longitude: number; latitude: number };
 
 export type GeolibDistanceFn = (
     point: GeolibInputCoordinates,


### PR DESCRIPTION
Support only objects with latitude and longitude keys.

```
const f = () => Geolib.getDistance({latitude: 52.03619585349617, longitude: 5.584403515509954}, {latitude: 52.03608085372884, longitude: 5.584578432841445})

console.log(f())
const t0 = Date.now()
for (let i = 0; i < 1000000; i++) {
    f()
}
const t1 = Date.now()
console.log(t1 - t0)
```


Main version of geolib: 900ms
FM improved version: 7ms
Old FM improved version: 400ms